### PR TITLE
Add TensorFlow NN with Bayesian loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # js
-html and js work
+
+This repository contains experimental JavaScript and Node.js code. The `relation` file is a React component with various ML utilities.
+
+## Neural network with Bayesian loop
+
+`nn_bayes.js` demonstrates a small TensorFlow.js model trained with the Adam optimizer. It generates synthetic data, trains a simple neural network, and then feeds the prediction into a Bayesian update.
+
+Run it with:
+
+```bash
+npm install
+npm start
+```

--- a/nn_bayes.js
+++ b/nn_bayes.js
@@ -1,0 +1,52 @@
+import * as tf from '@tensorflow/tfjs-node';
+
+// Generate synthetic data: features are 2D points, labels 0 or 1
+const dataSize = 100;
+const xsArray = [];
+const ysArray = [];
+for (let i = 0; i < dataSize; i++) {
+  const x1 = Math.random();
+  const x2 = Math.random();
+  xsArray.push([x1, x2]);
+  ysArray.push(x1 > x2 ? 1 : 0); // label depends on comparison
+}
+
+// Convert to tensors
+const xs = tf.tensor2d(xsArray);
+const ys = tf.tensor2d(ysArray, [dataSize, 1]);
+
+// Build a simple model using Adam optimizer
+const model = tf.sequential();
+model.add(tf.layers.dense({ units: 4, activation: 'relu', inputShape: [2] }));
+model.add(tf.layers.dense({ units: 1, activation: 'sigmoid' }));
+
+model.compile({ optimizer: tf.train.adam(0.05), loss: 'binaryCrossentropy' });
+
+// Train using a custom gradient loop for demonstration
+async function trainModel() {
+  const epochs = 50;
+  for (let i = 0; i < epochs; i++) {
+    const h = await model.fit(xs, ys, { epochs: 1, shuffle: true });
+    console.log(`Epoch ${i + 1}: loss=${h.history.loss[0].toFixed(4)}`);
+  }
+}
+
+// Simple Bayesian update: prior 0.5 updated by NN prediction as likelihood
+function bayesianUpdate(prior, likelihood) {
+  const marginal = likelihood * prior + (1 - likelihood) * (1 - prior);
+  return marginal > 0 ? (likelihood * prior) / marginal : prior;
+}
+
+async function run() {
+  await trainModel();
+  const testPoint = tf.tensor2d([[0.3, 0.7]]);
+  const prediction = model.predict(testPoint);
+  const prob = prediction.dataSync()[0];
+  console.log('NN prediction probability:', prob.toFixed(4));
+
+  let belief = 0.5; // prior
+  belief = bayesianUpdate(belief, prob);
+  console.log('Posterior belief:', belief.toFixed(4));
+}
+
+run();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ml-network",
+  "version": "1.0.0",
+  "description": "Neural network with Bayesian loop",
+  "main": "nn_bayes.js",
+  "type": "module",
+  "scripts": {
+    "start": "node nn_bayes.js"
+  },
+  "dependencies": {
+    "@tensorflow/tfjs-node": "^4.14.0"
+  }
+}


### PR DESCRIPTION
## Summary
- set up a simple Node.js entrypoint using TensorFlow.js
- demonstrate training a neural network with the Adam optimizer
- feed model output into a Bayesian update step
- document how to run the example

## Testing
- `node nn_bayes.js` *(fails: Cannot find package '@tensorflow/tfjs-node')*

------
https://chatgpt.com/codex/tasks/task_e_687bac8fde3883328b5250d1a19453f8