### PR TITLE
Add TensorFlow.js demo with Bayesian update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # js
 html and js work
+
+## Advanced TensorFlow Example
+
+This repository now includes a small TensorFlow.js demonstration in
+`advanced_tf.js`. It shows how to train a neural network with the Adam
+optimizer using matrix based operations and then feeds the predictions
+into a simple Bayesian update loop.
+
+Run it with:
+
+```bash
+node advanced_tf.js
+```
+
+The script assumes `@tensorflow/tfjs-node` is installed in the local
+environment.

--- a/advanced_tf.js
+++ b/advanced_tf.js
@@ -1,0 +1,53 @@
+const tf = require('@tensorflow/tfjs-node');
+
+// Create a simple neural network using TensorFlow.js
+function createModel(inputSize, hiddenSize, outputSize) {
+  const model = tf.sequential();
+  model.add(tf.layers.dense({ units: hiddenSize, inputShape: [inputSize], activation: 'relu' }));
+  model.add(tf.layers.dense({ units: outputSize, activation: 'sigmoid' }));
+  return model;
+}
+
+// Train the model using an Adam optimizer and manual gradient updates
+async function trainModel(model, xs, ys, epochs, learningRate) {
+  const optimizer = tf.train.adam(learningRate);
+  for (let i = 0; i < epochs; i++) {
+    // Compute gradients and update weights
+    optimizer.minimize(() => {
+      const preds = model.predict(xs);
+      return tf.losses.meanSquaredError(ys, preds);
+    });
+    if ((i + 1) % 20 === 0) {
+      const loss = tf.losses.meanSquaredError(ys, model.predict(xs));
+      console.log(`Epoch ${i + 1} loss: ${loss.dataSync()[0].toFixed(4)}`);
+    }
+  }
+}
+
+// Perform Bayesian update given prior and likelihood tensors
+function bayesianUpdate(prior, likelihood) {
+  const numerator = prior.mul(likelihood);
+  const denominator = numerator.add(prior.mul(-1).add(1).mul(likelihood.mul(-1).add(1)));
+  return numerator.div(denominator);
+}
+
+async function main() {
+  // XOR style training data
+  const xs = tf.tensor2d([[0, 0], [0, 1], [1, 0], [1, 1]]);
+  const ys = tf.tensor2d([[0], [1], [1], [0]]);
+
+  const model = createModel(2, 8, 1);
+  await trainModel(model, xs, ys, 200, 0.05);
+
+  const predictions = model.predict(xs);
+  predictions.print();
+
+  // Prior probabilities for Bayesian update (assume 0.5)
+  const prior = tf.fill([4, 1], 0.5);
+  const posterior = bayesianUpdate(prior, predictions);
+
+  console.log('Posterior beliefs after Bayesian update:');
+  posterior.print();
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "js",
+  "version": "1.0.0",
+  "description": "html and js work",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- add `advanced_tf.js` demonstrating an Adam-optimized NN with a Bayesian loop
- document how to run the demo
- include a minimal package.json for Node usage

## Testing
- `node advanced_tf.js` *(fails: Cannot find module '@tensorflow/tfjs-node')*

------
https://chatgpt.com/codex/tasks/task_e_687bac8fde3883328b5250d1a19453f8